### PR TITLE
Fix .oneline slides style.

### DIFF
--- a/html5/themes/mozilla/styles/style.css
+++ b/html5/themes/mozilla/styles/style.css
@@ -358,7 +358,6 @@ blockquote .quotesource {
 .slide.oneline h2 {
 	position:absolute;
 	top:50%;
-	width:100%;
 	text-align:left;
 	line-height:1;
 	font-size:70px;


### PR DESCRIPTION
When "oneline" slides are too long, the text overflows out of the slide. This
simple change prevents this.