### PR TITLE
Support multilingual slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Changes in this version:
 * Overall cleanup of the CSS (different list styles, live CSS code)
 * Pressing "N" in fullscreen mode toggles note display
 * In list mode, each slide has a "x" button to turn it on and off. This does not persist though, so when you reload your slides, it will make them all active again (TODO I guess)
+* Support for multilingual slides, with URLs that update. Toggle the menu option to get the text in your desired language. (only in HTML5 slidedeck)
 
 Next steps: 
 

--- a/html5/scripts/script.js
+++ b/html5/scripts/script.js
@@ -385,3 +385,29 @@ function goFullScreen() {
     requestFullscreen( document.documentElement );
   }
 }
+
+var lang = 'en-US';
+try {
+  lang = new URL(window.location).searchParams.get('lang');
+} catch (ex) {
+ // searchParams isn't supported in all browsers
+}
+
+// Pre-selects the correct current language on the dropdown menu
+document.getElementById('langMenuId').value = lang;
+
+function changeLanguage(){
+  var langObj = document.getElementById('langMenuId');
+  document.documentElement.lang = langObj.value;
+
+  // Update the language code in the URL bar
+  try {
+    var url = new URL(window.location);
+    url.searchParams.set('lang', langObj.value);
+    history.replaceState({}, document.title, url);
+  } catch (ex) {
+    // This might not be supported in all browsers
+  }
+}
+
+changeLanguage();

--- a/html5/scripts/script.js
+++ b/html5/scripts/script.js
@@ -97,7 +97,7 @@
   }
 
   function isListMode() {
-    return 'full' !== url.search.substr(1);
+    return 'full' !== url.search.substr(1, 4);
   }
 
   function normalizeSlideNumber(slideNumber) {

--- a/html5/template.html
+++ b/html5/template.html
@@ -70,10 +70,10 @@
       </header>
       <p>The following are callout slide styles – either a large word, or a one sentence headline. Use them to chunk your presentation into logical units.</p>
       <p>Multilingual content:</p>
-      <div class="en_us">This is English.</div>
-      <div class="zh_cn">这是中文（简体）。</div>
-      <div class="zh_tw">這是中文（繁體）。</div>
-      <div class="ja_jp">これは日本語です。</div>
+      <div class="en-US">This is English.</div>
+      <div class="zh-CN">这是中文（简体）。</div>
+      <div class="zh-TW">這是中文（繁體）。</div>
+      <div class="ja-JP">これは日本語です。</div>
       <footer class="notes">
       </footer>
     </section>
@@ -83,10 +83,10 @@
     <section>
       <header>
         <h2>
-          <div class="en_us">Shout slide</div>
-          <div class="zh_cn">标题</div>
-          <div class="zh_tw">標題</div>
-          <div class="ja_jp">タイトル</div>
+          <div class="en-US">Shout slide</div>
+          <div class="zh-CN">标题</div>
+          <div class="zh-TW">標題</div>
+          <div class="ja-JP">タイトル</div>
         </h2>
       </header>
       <footer class="notes">

--- a/html5/template.html
+++ b/html5/template.html
@@ -69,6 +69,11 @@
         <h2>Callout slide styles</h2>
       </header>
       <p>The following are callout slide styles – either a large word, or a one sentence headline. Use them to chunk your presentation into logical units.</p>
+      <p>Multilingual content:</p>
+      <div class="en_us">This is English.</div>
+      <div class="zh_cn">这是中文（简体）。</div>
+      <div class="zh_tw">這是中文（繁體）。</div>
+      <div class="ja_jp">これは日本語です。</div>
       <footer class="notes">
       </footer>
     </section>
@@ -77,7 +82,12 @@
   <div id="shout" class="slide shout"><div>
     <section>
       <header>
-        <h2>Shout slide</h2>
+        <h2>
+          <div class="en_us">Shout slide</div>
+          <div class="zh_cn">标题</div>
+          <div class="zh_tw">標題</div>
+          <div class="ja_jp">タイトル</div>
+        </h2>
       </header>
       <footer class="notes">
       </footer>
@@ -667,6 +677,15 @@
     just remove “progress” element.
     -->
   <div class="progress"><div></div></div>
+  <div id="langMenuDivId">
+    <!-- Having event.stopPropagation() prevents keypresses on the language menu from affecting slideshow progression -->
+    <select id="langMenuId" onchange="changeLanguage();" onkeydown="event.stopPropagation()">
+      <option value="en-US">English</option>
+      <option value="zh-CN">中文（简体）</option>
+      <option value="zh-TW">中文（繁體）</option>
+      <option value="ja-JP">日本語</option>
+    </select>
+  </div>
   <script src="scripts/script.js"></script>
   <!-- Copyright © 2010–2012 Vadim Makeev — pepelsbey.net -->
 </body>

--- a/html5/themes/mozilla/styles/style.css
+++ b/html5/themes/mozilla/styles/style.css
@@ -749,3 +749,28 @@ ul.inline li:last-child::after {
   50%  { transform: rotate(3deg) translate(-50%, -50%); }
   100% { transform: rotate(-3deg) translate(-50%, -50%); }
 }
+
+/* Multilingual support */
+
+.en_us,
+.zh_cn,
+.zh_tw,
+.ja_jp {
+	display: none;
+}
+
+:lang(en-US) .en_us,
+:lang(zh-CN) .zh_cn,
+:lang(zh-TW) .zh_tw,
+:lang(ja-JP) .ja_jp {
+	display: block;
+}
+
+
+#langMenuDivId {
+	position: absolute;
+	left: 0px;
+	right: 0px;
+	text-align: center;
+	bottom: 36px;
+}

--- a/html5/themes/mozilla/styles/style.css
+++ b/html5/themes/mozilla/styles/style.css
@@ -752,17 +752,17 @@ ul.inline li:last-child::after {
 
 /* Multilingual support */
 
-.en_us,
-.zh_cn,
-.zh_tw,
-.ja_jp {
+.en-US,
+.zh-CN,
+.zh-TW,
+.ja-JP {
 	display: none;
 }
 
-:lang(en-US) .en_us,
-:lang(zh-CN) .zh_cn,
-:lang(zh-TW) .zh_tw,
-:lang(ja-JP) .ja_jp {
+:lang(en-US) .en-US,
+:lang(zh-CN) .zh-CN,
+:lang(zh-TW) .zh-TW,
+:lang(ja-JP) .ja-JP {
 	display: block;
 }
 


### PR DESCRIPTION
I have added support for multilingual slides. By choosing the desired language option, the slides that have content within the respective language class names (e.g. "en-US" and "zh-TW") will switch between them.

The language change is persistent across slides, and in Firefox, the URL bar will update the lang attribute as well.

In this pull request, only the 2nd and 3rd (shout slide) slides have multilingual content as an example.

Credits to :MattN for greatly helping me out throughout.